### PR TITLE
Update regeneration effect duration and tick rate

### DIFF
--- a/data/origins-plus-plus/powers/wizard/magic.json
+++ b/data/origins-plus-plus/powers/wizard/magic.json
@@ -1,8 +1,9 @@
 {
 	"type":"origins:stacking_status_effect",
-	"min_stacks":4,
-	"max_stacks":4,
-	"duration_per_stack":20,
+	"min_stacks": 0,
+	"max_stacks": 1,
+	"duration_per_stack": 60,
+	"tick_rate": 60,
 	"effect":{
 		"effect":"minecraft:regeneration",
 		"show_particles":false,


### PR DESCRIPTION
This pull request updates the regeneration effect duration and tick rate for the stacking_status_effect. The previous duration per stack was 20 seconds, but it has been changed to 60 seconds. Additionally, the tick rate has been set to 60. This change ensures that the regeneration effect lasts longer and ticks more frequently, providing a more effective healing effect.